### PR TITLE
Support error fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,15 @@ console.log(value);
 
 ### Options
 
+#### `errorFallback`
+
+Create a fallback node if processing of a mermaid diagram fails. If nothing is returned, the code
+block is removed. The function receives the following arguments:
+
+- `node`: The mdast `code` node that couldn’t be rendered.
+- `error`: The error message that was thrown.
+- `file`: The file on which the error occurred.
+
 #### `launchOptions`
 
 These options are passed to

--- a/browser.ts
+++ b/browser.ts
@@ -1,15 +1,14 @@
 import { fromDom } from 'hast-util-from-dom';
-import { type Code, type Parent, type Root } from 'mdast';
+import { type Code, type Parent } from 'mdast';
 import mermaid from 'mermaid';
-import { type Plugin } from 'unified';
+import type { RemarkMermaid } from 'remark-mermaidjs';
 import { visit } from 'unist-util-visit';
 
-// eslint-disable-next-line jsdoc/require-jsdoc
-function transformer(ast: Root): void {
-  const instances: [string, number, Parent][] = [];
+const remarkMermaid: RemarkMermaid = (options) => (ast, file) => {
+  const instances: [Code, number, Parent][] = [];
 
   visit(ast, { type: 'code', lang: 'mermaid' }, (node: Code, index, parent: Parent) => {
-    instances.push([node.value, index, parent]);
+    instances.push([node, index, parent]);
   });
 
   // Nothing to do. No need to start puppeteer in this case.
@@ -17,23 +16,38 @@ function transformer(ast: Root): void {
     return;
   }
 
-  const results = instances.map(([code], index) =>
-    // @ts-expect-error The mermaid types are wrong.
-    mermaid.render(`remark-mermaid-${index}`, code),
-  );
+  const results: string[] = [];
+  const errors: string[] = [];
+  for (const [index, [node]] of instances.entries()) {
+    try {
+      // @ts-expect-error The mermaid types are wrong.
+      results[index] = mermaid.render(`remark-mermaid-${index}`, node.value);
+    } catch (error) {
+      errors[index] = error instanceof Error ? error.message : String(error);
+    }
+  }
 
   const wrapper = document.createElement('div');
-  for (const [i, [, index, parent]] of instances.entries()) {
-    const value = results[i];
-    wrapper.innerHTML = value;
-    parent.children.splice(index, 1, {
-      type: 'paragraph',
-      children: [{ type: 'html', value }],
-      data: { hChildren: [fromDom(wrapper.firstChild!)] },
-    });
+  for (const [i, [node, index, parent]] of instances.entries()) {
+    if (i in results) {
+      const value = results[i];
+      wrapper.innerHTML = value;
+      parent.children.splice(index, 1, {
+        type: 'paragraph',
+        children: [{ type: 'html', value }],
+        data: { hChildren: [fromDom(wrapper.firstChild!)] },
+      });
+    } else if (options?.errorFallback) {
+      const fallback = options.errorFallback(node, errors[i], file);
+      if (fallback) {
+        parent.children[index] = fallback;
+      } else {
+        parent.children.splice(index, 1);
+      }
+    } else {
+      file.fail(errors[i], node, 'remark-mermaidjs:remark-mermaidjs');
+    }
   }
-}
-
-const remarkMermaid: Plugin<[], Root> = () => transformer;
+};
 
 export default remarkMermaid;

--- a/browser.ts
+++ b/browser.ts
@@ -1,53 +1,37 @@
 import { fromDom } from 'hast-util-from-dom';
-import { type Code, type Parent } from 'mdast';
 import mermaid from 'mermaid';
-import type { RemarkMermaid } from 'remark-mermaidjs';
-import { visit } from 'unist-util-visit';
+import { type RemarkMermaid } from 'remark-mermaidjs';
+
+import { extractCodeBlocks, replaceCodeBlocks } from './shared.js';
 
 const remarkMermaid: RemarkMermaid = (options) => (ast, file) => {
-  const instances: [Code, number, Parent][] = [];
+  const instances = extractCodeBlocks(ast);
 
-  visit(ast, { type: 'code', lang: 'mermaid' }, (node: Code, index, parent: Parent) => {
-    instances.push([node, index, parent]);
-  });
-
-  // Nothing to do. No need to start puppeteer in this case.
+  // Nothing to do. No need to do further processing.
   if (!instances.length) {
     return;
   }
 
-  const results: string[] = [];
-  const errors: string[] = [];
-  for (const [index, [node]] of instances.entries()) {
+  const results = instances.map(([node], index) => {
     try {
-      // @ts-expect-error The mermaid types are wrong.
-      results[index] = mermaid.render(`remark-mermaid-${index}`, node.value);
+      return {
+        success: true,
+        // @ts-expect-error The mermaid types are wrong.
+        result: mermaid.render(`remark-mermaid-${index}`, node.value),
+      };
     } catch (error) {
-      errors[index] = error instanceof Error ? error.message : String(error);
+      return {
+        success: false,
+        result: error instanceof Error ? error.message : String(error),
+      };
     }
-  }
+  });
 
   const wrapper = document.createElement('div');
-  for (const [i, [node, index, parent]] of instances.entries()) {
-    if (i in results) {
-      const value = results[i];
-      wrapper.innerHTML = value;
-      parent.children.splice(index, 1, {
-        type: 'paragraph',
-        children: [{ type: 'html', value }],
-        data: { hChildren: [fromDom(wrapper.firstChild!)] },
-      });
-    } else if (options?.errorFallback) {
-      const fallback = options.errorFallback(node, errors[i], file);
-      if (fallback) {
-        parent.children[index] = fallback;
-      } else {
-        parent.children.splice(index, 1);
-      }
-    } else {
-      file.fail(errors[i], node, 'remark-mermaidjs:remark-mermaidjs');
-    }
-  }
+  replaceCodeBlocks(instances, results, options, file, (value) => {
+    wrapper.innerHTML = value;
+    return [value, fromDom(wrapper.firstChild!)];
+  });
 };
 
 export default remarkMermaid;

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "puppeteer-core": "^19.0.0",
     "svgo": "^3.0.0",
     "unified": "^10.0.0",
-    "unist-util-visit": "^4.0.0"
+    "unist-util-visit": "^4.0.0",
+    "vfile": "^5.0.0"
   },
   "devDependencies": {
     "@playwright/test": "^1.0.0",

--- a/shared.ts
+++ b/shared.ts
@@ -1,0 +1,74 @@
+import { type Node } from 'hast';
+import { type Code, type Parent, type Root } from 'mdast';
+import { visit } from 'unist-util-visit';
+import { type VFile } from 'vfile';
+
+import { type RemarkMermaidOptions } from './index.js';
+
+type CodeInstance = [Code, number, Parent];
+
+/**
+ * Extract Mermaid code blocks from the AST.
+ *
+ * @param ast The markdown AST to extract code blocks from.
+ * @returns A list of tuples that represent the code blocks.
+ */
+export function extractCodeBlocks(ast: Root): CodeInstance[] {
+  const instances: CodeInstance[] = [];
+
+  visit(ast, { type: 'code', lang: 'mermaid' }, (node: Code, index, parent: Parent) => {
+    instances.push([node, index, parent]);
+  });
+
+  return instances;
+}
+
+export interface Result {
+  /**
+   * This indicates diagram was rendered succesfully.
+   */
+  success: boolean;
+
+  /**
+   * Either the resulting SVG code or the error message depending on the success status.
+   */
+  result: string;
+}
+
+/**
+ * Replace the code blocks with rendered diagrams.
+ *
+ * @param instances The code block instances to replace.
+ * @param results The diagram rendering results.
+ * @param options The `remark-mermaidjs` options as given by the user.
+ * @param file The file to report errors on.
+ * @param processDiagram Postprocess a diagram.
+ */
+export function replaceCodeBlocks(
+  instances: CodeInstance[],
+  results: Result[],
+  options: RemarkMermaidOptions | undefined,
+  file: VFile,
+  processDiagram: (diagram: string) => [string, Node],
+): void {
+  for (const [i, [node, index, parent]] of instances.entries()) {
+    const result = results[i];
+    if (result.success) {
+      const [value, hChild] = processDiagram(result.result);
+      parent.children[index] = {
+        type: 'paragraph',
+        children: [{ type: 'html', value }],
+        data: { hChildren: [hChild] },
+      };
+    } else if (options?.errorFallback) {
+      const fallback = options.errorFallback(node, result.result, file);
+      if (fallback) {
+        parent.children[index] = fallback;
+      } else {
+        parent.children.splice(index, 1);
+      }
+    } else {
+      file.fail(result.result, node, 'remark-mermaidjs:remark-mermaidjs');
+    }
+  }
+}

--- a/test/fixtures/error/input.md
+++ b/test/fixtures/error/input.md
@@ -1,0 +1,9 @@
+# Error
+
+This is an invalid diagram
+
+```mermaid
+invalid
+```
+
+More content

--- a/test/fixtures/error/options.ts
+++ b/test/fixtures/error/options.ts
@@ -1,0 +1,10 @@
+import type { RemarkMermaidOptions } from 'remark-mermaidjs';
+
+export const options: RemarkMermaidOptions = {
+  errorFallback(node, error, vfile) {
+    return {
+      type: 'code',
+      value: `${vfile.basename}\n\n${error}\n\n${JSON.stringify(node, undefined, 2)}`,
+    };
+  },
+};

--- a/test/fixtures/errorEmpty/input.md
+++ b/test/fixtures/errorEmpty/input.md
@@ -1,0 +1,9 @@
+# Error
+
+This is an invalid diagram
+
+```mermaid
+invalid
+```
+
+More content

--- a/test/fixtures/errorEmpty/options.ts
+++ b/test/fixtures/errorEmpty/options.ts
@@ -1,0 +1,6 @@
+import type { RemarkMermaidOptions } from 'remark-mermaidjs';
+
+export const options: RemarkMermaidOptions = {
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  errorFallback() {},
+};

--- a/test/runInBrowser.ts
+++ b/test/runInBrowser.ts
@@ -1,8 +1,13 @@
 import rehypeStringify from 'rehype-stringify';
 import { remark } from 'remark';
+import { type RemarkMermaidOptions } from 'remark-mermaidjs';
 import remarkRehype from 'remark-rehype';
 
 import remarkMermaid from '../browser.js';
+import { options as error } from './fixtures/error/options.js';
+import { options as errorEmpty } from './fixtures/errorEmpty/options.js';
+
+const options: Record<string, RemarkMermaidOptions> = { error, errorEmpty };
 
 /**
  * Process a fixture using remark and remark-mermaidjs.
@@ -13,10 +18,12 @@ import remarkMermaid from '../browser.js';
  * @returns A tuple of the file processed to both markdown and HTML.
  */
 export async function processFixture(name: string): Promise<[string, string]> {
-  const response = await fetch(`fixtures/${name}/input.md`);
-  const original = await response.text();
-  const processor = remark().use(remarkMermaid);
-  const asMarkdown = processor.processSync(original);
-  const asHTML = processor().use(remarkRehype).use(rehypeStringify).processSync(original);
+  const testOptions = name in options ? options[name] : undefined;
+  const path = `fixtures/${name}/input.md`;
+  const response = await fetch(path);
+  const value = await response.text();
+  const processor = remark().use(remarkMermaid, testOptions);
+  const asMarkdown = processor.processSync({ path, value });
+  const asHTML = processor().use(remarkRehype).use(rehypeStringify).processSync({ path, value });
   return [asMarkdown.value as string, asHTML.value as string];
 }

--- a/test/test.ts-snapshots/error-browser.html
+++ b/test/test.ts-snapshots/error-browser.html
@@ -1,0 +1,26 @@
+<h1>Error</h1>
+<p>This is an invalid diagram</p>
+<pre><code>input.md
+
+No diagram type detected for text: invalid
+
+{
+  "type": "code",
+  "lang": "mermaid",
+  "meta": null,
+  "value": "invalid",
+  "position": {
+    "start": {
+      "line": 5,
+      "column": 1,
+      "offset": 37
+    },
+    "end": {
+      "line": 7,
+      "column": 4,
+      "offset": 59
+    }
+  }
+}
+</code></pre>
+<p>More content</p>

--- a/test/test.ts-snapshots/error-browser.md
+++ b/test/test.ts-snapshots/error-browser.md
@@ -1,0 +1,28 @@
+# Error
+
+This is an invalid diagram
+
+    input.md
+
+    No diagram type detected for text: invalid
+
+    {
+      "type": "code",
+      "lang": "mermaid",
+      "meta": null,
+      "value": "invalid",
+      "position": {
+        "start": {
+          "line": 5,
+          "column": 1,
+          "offset": 37
+        },
+        "end": {
+          "line": 7,
+          "column": 4,
+          "offset": 59
+        }
+      }
+    }
+
+More content

--- a/test/test.ts-snapshots/error-node.html
+++ b/test/test.ts-snapshots/error-node.html
@@ -1,0 +1,26 @@
+<h1>Error</h1>
+<p>This is an invalid diagram</p>
+<pre><code>input.md
+
+No diagram type detected for text: invalid
+
+{
+  "type": "code",
+  "lang": "mermaid",
+  "meta": null,
+  "value": "invalid",
+  "position": {
+    "start": {
+      "line": 5,
+      "column": 1,
+      "offset": 37
+    },
+    "end": {
+      "line": 7,
+      "column": 4,
+      "offset": 59
+    }
+  }
+}
+</code></pre>
+<p>More content</p>

--- a/test/test.ts-snapshots/error-node.md
+++ b/test/test.ts-snapshots/error-node.md
@@ -1,0 +1,28 @@
+# Error
+
+This is an invalid diagram
+
+    input.md
+
+    No diagram type detected for text: invalid
+
+    {
+      "type": "code",
+      "lang": "mermaid",
+      "meta": null,
+      "value": "invalid",
+      "position": {
+        "start": {
+          "line": 5,
+          "column": 1,
+          "offset": 37
+        },
+        "end": {
+          "line": 7,
+          "column": 4,
+          "offset": 59
+        }
+      }
+    }
+
+More content

--- a/test/test.ts-snapshots/errorEmpty-browser.html
+++ b/test/test.ts-snapshots/errorEmpty-browser.html
@@ -1,0 +1,3 @@
+<h1>Error</h1>
+<p>This is an invalid diagram</p>
+<p>More content</p>

--- a/test/test.ts-snapshots/errorEmpty-browser.md
+++ b/test/test.ts-snapshots/errorEmpty-browser.md
@@ -1,0 +1,5 @@
+# Error
+
+This is an invalid diagram
+
+More content

--- a/test/test.ts-snapshots/errorEmpty-node.html
+++ b/test/test.ts-snapshots/errorEmpty-node.html
@@ -1,0 +1,3 @@
+<h1>Error</h1>
+<p>This is an invalid diagram</p>
+<p>More content</p>

--- a/test/test.ts-snapshots/errorEmpty-node.md
+++ b/test/test.ts-snapshots/errorEmpty-node.md
@@ -1,0 +1,5 @@
+# Error
+
+This is an invalid diagram
+
+More content


### PR DESCRIPTION
If the user provides `errorFallback`, it will be called when mermaid throws an error. It will receive the faulty code node, the mermaid error message, and the vfile as arguments, and may return a node to replace the code. If nothing is returned from the fallback, the code will be removed instead. To keep the code as-is, simply return the it from the fallback.

Also if no error fallback is provided, errors are now handled gracefully using `file.fail()`.

Closes #10